### PR TITLE
[AP-1672] Don't flip the source / destination of volumes.

### DIFF
--- a/ssh-ecs-run-task
+++ b/ssh-ecs-run-task
@@ -338,7 +338,7 @@ exit 0
             VOLUME_ARGS+=(-v)
             VOLUME_ARGS+=("'$volume_arg'")
         done < <(echo $container | json -a .mountPoints |
-                    json -e "this.volumes=$task_volumes; this.volume_arg = this.containerPath + ':' + this.volumes[this.sourceVolume]" |
+                    json -e "this.volumes=$task_volumes; this.volume_arg = this.volumes[this.sourceVolume] + ':' + this.containerPath" |
                     json -a .volume_arg)
     fi
 


### PR DESCRIPTION
Hallo @mvpc @jlburkhead @igotsidetrackded @matthewcburke 

We're using ssh-ecs-run-task to start an integration test task out in alpha and staging and were having a hard time figuring our why we couldn't load in secrets from a volume that other services have been using since forever.

Turns out ssh-ecs-run-task was flipping the order of the -v arguments such that they would only ever work if the mount was "reversible" (e.g. "/secrets:/secrets" works, but "/etc/socialcode/tls:/tls" becomes a tricksy 🐛 !)

Looks like this will eventually be tagged as `0.0.14` and I'll build/distribute it to the python-repo.